### PR TITLE
Exclude files in tmp and public/system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
--
+- Exclude files in `tmp` and `public/system`.
 
 
 ## 3.1.0 - 2019-02-29

--- a/config/default.yml
+++ b/config/default.yml
@@ -62,6 +62,8 @@ AllCops:
     - 'vendor/**/*'
     - '.git/**/*'
     - 'bin/**/*'
+    - 'tmp/**/*'
+    - 'public/system/**/*'
     - 'db/schema.rb'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress


### PR DESCRIPTION
I sometimes use Ruby files when testing file attachments, and this can cause rubocop to start failing.