### PR TITLE
Upgrade cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Breaking changes
 
-### Compatible changes
+- Upgrade `rubocop`
+- Upgrade `rubocop-rails`
+
+Migration notes:
+
+In case you are using a project with Ruby < 2.5 you need to add these lines to your `.rubocop.yml`:
+
+```
+Style/HashTransformKeys:
+  Enable: false # Disabled until Ruby 2.5 upgrade
+
+Style/HashTransformValues:
+  Enable: false # Disabled until Ruby 2.5 upgrade
+```
 
 
 ## 4.4.0 - 2020-04-06

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,23 @@ PATH
   specs:
     makandra-rubocop (4.4.0)
       rubocop (~> 0.81.0)
-      rubocop-rails (~> 2.3.2)
+      rubocop-rails (~> 2.5.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    minitest (5.14.0)
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
@@ -25,11 +35,16 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-rails (2.3.2)
+    rubocop-rails (2.5.1)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     makandra-rubocop (4.4.0)
-      rubocop (~> 0.76.0)
+      rubocop (~> 0.81.0)
       rubocop-rails (~> 2.3.2)
 
 GEM
@@ -16,18 +16,20 @@ GEM
     rack (2.2.2)
     rainbow (3.0.0)
     rake (12.3.2)
-    rubocop (0.76.0)
+    rexml (3.2.4)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ See [Rubocop's configuration manual](https://github.com/rubocop-hq/rubocop/blob/
 Note that disabling cops should be an exception for extremely rare cases where your code can not be aligned with Rubocop's requirements.
 If our defaults don't match your opinion, you should discuss with the team.
 
-
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -112,12 +111,12 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 2. `bundle`
 3. `git add remote rubocop https://github.com/rubocop-hq/rubocop.git`
 4. `git fetch rubocop --no-tags` (we can't import their tags or they would clash with ours)
-5. Find out the commit SHA of the release you put into the gemspec.
-6. `git checkout COMMIT_SHA config/default.yml`
-7. `git reset` to unstage the changes you just picked
-8. Review all changes and stage those that you want. Note that cop settings will be reverted to their default settings and that you do not want to add them all.
-9. Commit.
+5. Find out the commit SHA of the release you put into the gemspec and the commit SHA of the newest release (with a tag).
+6. `git diff $OLDER_SHA $NEWER_SHA config/default.yml | git apply --3way`
+7. Resolve the merge conflicts carefully and review all changes. We do not want to loose our overrides.
+8. Commit.
 
+This procedure is the same for `rubocop-rails`.
 
 ## Contributing
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -564,7 +564,7 @@ Layout/FirstArgumentIndentation:
   Enabled: true
   VersionAdded: '0.68'
   VersionChanged: '0.77'
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  EnforcedStyle: consistent
   SupportedStyles:
     # The first parameter should always be indented one step more than the
     # preceding line.
@@ -1722,7 +1722,7 @@ Lint/StructNewOverride:
 Lint/SuppressedException:
   Description: "Don't suppress exceptions."
   StyleGuide: '#dont-hide-exceptions'
-  Enabled: false
+  Enabled: true
   AllowComments: true
   VersionAdded: '0.9'
   VersionChanged: '0.81'
@@ -1952,7 +1952,7 @@ Naming/BlockParameterName:
   Description: >-
                  Checks for block parameter names that contain capital letters,
                  end in numbers, or do not meet a minimal length.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.77'
   # Parameter names may be equal to or greater than this value
@@ -2090,11 +2090,11 @@ Naming/MethodParameterName:
   Description: >-
                  Checks for method parameter names that contain capital letters,
                  end in numbers, or do not meet a minimal length.
-  Enabled: false
+  Enabled: true
   VersionAdded: '0.53'
   VersionChanged: '0.77'
   # Parameter names may be equal to or greater than this value
-  MinNameLength: 3
+  MinNameLength: 1
   AllowNamesEndingInNumbers: true
   # Allowed names that will not register an offense
   AllowedNames:
@@ -3864,7 +3864,7 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInBlockArgs:
   Description: 'Checks for useless trailing commas in block arguments.'
-  Enabled: false
+  Enabled: false # We want to enabled this cop later, currently it is not working properly
   Safe: false
   VersionAdded: '0.81'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -54,11 +54,13 @@ AllCops:
     - '**/Puppetfile'
     - '**/Rakefile'
     - '**/Snapfile'
+    - '**/Steepfile'
     - '**/Thorfile'
     - '**/Vagabondfile'
     - '**/Vagrantfile'
   Exclude:
     - 'node_modules/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
     - '.git/**/*'
     - 'bin/**/*'
@@ -145,11 +147,12 @@ Bundler/GemComment:
   Description: 'Add a comment describing each gem.'
   Enabled: false
   VersionAdded: '0.59'
+  VersionChanged: '0.77'
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
-  Whitelist: []
+  IgnoredGems: []
 
 Bundler/InsecureProtocolSource:
   Description: >-
@@ -199,9 +202,10 @@ Gemspec/RequiredRubyVersion:
   VersionAdded: '0.52'
   Include:
     - '**/*.gemspec'
-    -
+
 Gemspec/RubyVersionGlobalsUsage:
   Description: Checks usage of RUBY_VERSION in gemspec.
+  StyleGuide: '#no-ruby-version-in-the-gemspec'
   Enabled: false
   VersionAdded: '0.72'
   Include:
@@ -222,13 +226,14 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Description: >-
     Align the arguments of a method call if they span more
     than one line.
   StyleGuide: '#no-double-indent'
   Enabled: false
   VersionAdded: '0.68'
+  VersionChanged: '0.77'
   # Alignment of arguments in multi-line method calls.
   #
   # The `with_first_argument` style aligns the following lines along the same
@@ -250,117 +255,43 @@ Layout/AlignArguments:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: >-
-    Align the elements of an array literal if they span more than
-    one line.
-  StyleGuide: '#align-multiline-arrays'
-  Enabled: false
-  VersionAdded: '0.49'
-
-Layout/AlignHash:
-  Description: >-
-    Align the elements of a hash literal if they span more than
-    one line.
-  Enabled: false
-  AllowMultipleStyles: true
-  VersionAdded: '0.49'
-  # Alignment of entries using hash rocket as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   'a' => 2
-  #   'bb' => 3
-  # separator - alignment of hash rockets, keys are right aligned
-  #    'a' => 2
-  #   'bb' => 3
-  # table - left alignment of keys, hash rockets, and values
-  #   'a'  => 2
-  #   'bb' => 3
-  EnforcedHashRocketStyle: key
-  SupportedHashRocketStyles:
-    - key
-    - separator
-    - table
-  # Alignment of entries using colon as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   a: 0
-  #   bb: 1
-  # separator - alignment of colons, keys are right aligned
-  #    a: 0
-  #   bb: 1
-  # table - left alignment of keys and values
-  #   a:  0
-  #   bb: 1
-  EnforcedColonStyle: key
-  SupportedColonStyles:
-    - key
-    - separator
-    - table
-  # Select whether hashes that are the last argument in a method call should be
-  # inspected? Valid values are:
-  #
-  # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # always_ignore - Ignore both implicit and explicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_implicit - Ignore only implicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_explicit - Ignore only explicit hashes.
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-    - always_inspect
-    - always_ignore
-    - ignore_implicit
-    - ignore_explicit
-
-Layout/AlignParameters:
-  Description: >-
-    Align the parameters of a method definition if they span more
-    than one line.
+                 Align the elements of an array literal if they span more than
+                 one line.
   StyleGuide: '#no-double-indent'
   Enabled: false
   VersionAdded: '0.49'
-  VersionChanged: '0.68'
-  # Alignment of parameters in multi-line method calls.
+  VersionChanged: '0.77'
+  # Alignment of elements of a multi-line array.
   #
   # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first parameter.
+  # column as the first element.
   #
-  #     def method_foo(a,
-  #                    b)
+  #     array = [1, 2, 3,
+  #              4, 5, 6]
   #
   # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
+  # level of indentation relative to the start of the line with start of array.
   #
-  #     def method_foo(a,
-  #       b)
-  EnforcedStyle: with_first_parameter
+  #     array = [1, 2, 3,
+  #       4, 5, 6]
+  EnforcedStyle: with_first_element
   SupportedStyles:
-    - with_first_parameter
+    - with_first_element
     - with_fixed_indentation
   # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/AssignmentIndentation:
+  Description: >-
+                Checks the indentation of the first line of the
+                right-hand-side of a multi-line assignment.
+  Enabled: false # We do not want to write the assignment in the following line
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  # By default, the indentation width from `Layout/IndentationWidth` is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
@@ -628,56 +559,11 @@ Layout/ExtraSpacing:
   # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
-Layout/FirstArrayElementLineBreak:
-  Description: >-
-    Checks for a line break before the first element in a
-    multi-line array.
-  Enabled: false
-  VersionAdded: '0.49'
-
-Layout/FirstHashElementLineBreak:
-  Description: >-
-    Checks for a line break before the first element in a
-    multi-line hash.
-  Enabled: false
-  VersionAdded: '0.49'
-
-Layout/FirstMethodArgumentLineBreak:
-  Description: >-
-    Checks for a line break before the first argument in a
-    multi-line method call.
-  Enabled: false
-  VersionAdded: '0.49'
-
-Layout/FirstMethodParameterLineBreak:
-  Description: >-
-    Checks for a line break before the first parameter in a
-    multi-line method parameter definition.
-  Enabled: false
-  VersionAdded: '0.49'
-
-Layout/HeredocArgumentClosingParenthesis:
-  Description: >-
-    Checks for the placement of the closing parenthesis in a
-    method call that passes a HEREDOC string as an argument.
-  Enabled: false
-  StyleGuide: '#heredoc-argument-closing-parentheses'
-  VersionAdded: '0.68'
-
-Layout/IndentAssignment:
-  Description: >-
-    Checks the indentation of the first line of the
-    right-hand-side of a multi-line assignment.
-  Enabled: false # We do not want to write the assignment in the following line
-  VersionAdded: '0.49'
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Description: 'Checks the indentation of the first argument in a method call.'
   Enabled: true
   VersionAdded: '0.68'
+  VersionChanged: '0.77'
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:
     # The first parameter should always be indented one step more than the
@@ -698,12 +584,13 @@ Layout/IndentFirstArgument:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Description: >-
     Checks the indentation of the first element in an array
     literal.
   Enabled: true
   VersionAdded: '0.68'
+  VersionChanged: '0.77'
   # The value `special_inside_parentheses` means that array literals with
   # brackets that have their opening bracket on the same line as a surrounding
   # opening round parenthesis, shall have their first element indented relative
@@ -724,10 +611,18 @@ Layout/IndentFirstArrayElement:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentFirstHashElement:
+Layout/FirstArrayElementLineBreak:
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line array.
+  Enabled: false
+  VersionAdded: '0.49'
+
+Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
   Enabled: true
   VersionAdded: '0.68'
+  VersionChanged: '0.77'
   # The value `special_inside_parentheses` means that hash literals with braces
   # that have their opening brace on the same line as a surrounding opening
   # round parenthesis, shall have their first key indented relative to the
@@ -748,13 +643,34 @@ Layout/IndentFirstHashElement:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentFirstParameter:
+Layout/FirstHashElementLineBreak:
+  Description: >-
+                 Checks for a line break before the first element in a
+                 multi-line hash.
+  Enabled: false
+  VersionAdded: '0.49'
+
+Layout/FirstMethodArgumentLineBreak:
+  Description: >-
+                 Checks for a line break before the first argument in a
+                 multi-line method call.
+  Enabled: false
+  VersionAdded: '0.49'
+
+Layout/FirstMethodParameterLineBreak:
+  Description: >-
+                 Checks for a line break before the first parameter in a
+                 multi-line method parameter definition.
+  Enabled: false
+  VersionAdded: '0.49'
+
+Layout/FirstParameterIndentation:
   Description: >-
     Checks the indentation of the first parameter in a
     method definition.
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.68'
+  VersionChanged: '0.77'
   EnforcedStyle: consistent
   SupportedStyles:
     - consistent
@@ -763,12 +679,98 @@ Layout/IndentFirstParameter:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentHeredoc:
+Layout/HashAlignment:
+  Description: >-
+    Align the elements of a hash literal if they span more than
+    one line.
+  Enabled: false
+  AllowMultipleStyles: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   'a' => 2
+  #   'bb' => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    'a' => 2
+  #   'bb' => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   'a'  => 2
+  #   'bb' => 3
+  EnforcedHashRocketStyle: key
+  SupportedHashRocketStyles:
+    - key
+    - separator
+    - table
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
+  EnforcedColonStyle: key
+  SupportedColonStyles:
+    - key
+    - separator
+    - table
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
+
+Layout/HeredocArgumentClosingParenthesis:
+  Description: >-
+                 Checks for the placement of the closing parenthesis in a
+                 method call that passes a HEREDOC string as an argument.
+  Enabled: false
+  StyleGuide: '#heredoc-argument-closing-parentheses'
+  VersionAdded: '0.68'
+
+Layout/HeredocIndentation:
   Description: 'This cop checks the indentation of the here document bodies.'
   StyleGuide: '#squiggly-heredocs'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.69'
+  VersionChanged: '0.77'
   EnforcedStyle: squiggly
   SupportedStyles:
     - squiggly
@@ -810,11 +812,6 @@ Layout/InitialIndentation:
   Enabled: true
   VersionAdded: '0.49'
 
-Layout/LeadingBlankLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
-  Enabled: true
-  VersionAdded: '0.57'
-
 Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
   StyleGuide: '#hash-space'
@@ -822,6 +819,36 @@ Layout/LeadingCommentSpace:
   VersionAdded: '0.49'
   VersionChanged: '0.73'
   AllowDoxygenCommentStyle: false
+  AllowGemfileRubyComment: false
+
+Layout/LeadingEmptyLines:
+  Description: Check for unnecessary blank lines at the beginning of a file.
+  Enabled: true
+  VersionAdded: '0.57'
+  VersionChanged: '0.77'
+
+Layout/LineLength:
+  Description: 'Limit lines to 80 characters.'
+  StyleGuide: '#80-character-limits'
+  Enabled: false
+  VersionAdded: '0.25'
+  VersionChanged: '0.78'
+  AutoCorrect: false
+  Max: 80
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # directives like '# rubocop: enable ...' when calculating a line's length.
+  IgnoreCopDirectives: true
+  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
+  # elements. Strings will be converted to Regexp objects. A line that matches
+  # any regular expression listed in this option will be ignored by LineLength.
+  IgnoredPatterns: []
 
 Layout/MultilineArrayBraceLayout:
   Description: >-
@@ -964,6 +991,35 @@ Layout/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/ParameterAlignment:
+  Description: >-
+                 Align the parameters of a method definition if they span more
+                 than one line.
+  StyleGuide: '#no-double-indent'
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     def method_foo(a,
+  #                    b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     def method_foo(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
   Enabled: false # Temporary disable this cop again #16, rubocop-hq/rubocop#6771 seems not have fixed the issue
@@ -1037,6 +1093,10 @@ Layout/SpaceAroundOperators:
   # with an operator on the previous or next line, not counting empty lines
   # or comment lines.
   AllowForAlignment: true
+  EnforcedStyleForExponentOperator: no_space
+  SupportedStylesForExponentOperator:
+    - space
+    - no_space
 
 Layout/SpaceBeforeBlockBraces:
   Description: >-
@@ -1206,11 +1266,12 @@ Layout/Tab:
   # replace each tab.
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: '#newline-eof'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.77'
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -1266,6 +1327,7 @@ Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
   VersionAdded: '0.50'
+  VersionChanged: '0.81'
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
@@ -1294,15 +1356,16 @@ Lint/DuplicateCaseCondition:
   Enabled: true
   VersionAdded: '0.45'
 
+Lint/DuplicateHashKey:
+  Description: 'Check for duplicate keys in hash literals.'
+  Enabled: true
+  VersionAdded: '0.34'
+  VersionChanged: '0.77'
+
 Lint/DuplicateMethods:
   Description: 'Check for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
-
-Lint/DuplicatedKey:
-  Description: 'Check for duplicate keys in hash literals.'
-  Enabled: true
-  VersionAdded: '0.34'
 
 Lint/EachWithObjectArgument:
   Description: 'Check for immutable argument given to each_with_object.'
@@ -1337,11 +1400,6 @@ Lint/EmptyWhen:
   Enabled: false # We want to write comments in when branches without any return value https://github.com/makandra/makandra-rubocop/issues/18
   VersionAdded: '0.45'
 
-Lint/EndInMethod:
-  Description: 'END blocks should not be placed inside method definitions.'
-  Enabled: true
-  VersionAdded: '0.9'
-
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'
   StyleGuide: '#no-return-ensure'
@@ -1370,14 +1428,6 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
   VersionAdded: '0.33'
-
-Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  StyleGuide: '#dont-hide-exceptions'
-  Enabled: false
-  AllowComments: false
-  VersionAdded: '0.9'
-  VersionChanged: '0.70'
 
 Lint/HeredocMethodCallPosition:
   Description: >-
@@ -1448,10 +1498,11 @@ Lint/MissingCopEnableDirective:
   # .inf for any size
   MaximumRangeSize: .inf
 
-Lint/MultipleCompare:
-  Description: "Use `&&` operator to compare multiple value."
+Lint/MultipleComparison:
+  Description: "Use `&&` operator to compare multiple values."
   Enabled: true
   VersionAdded: '0.47'
+  VersionChanged: '0.77'
 
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'
@@ -1470,6 +1521,12 @@ Lint/NextWithoutAccumulator:
     in a `reduce`/`inject` block.
   Enabled: true
   VersionAdded: '0.36'
+
+Lint/NonDeterministicRequireOrder:
+  Description: 'Always sort arrays returned by Dir.glob when requiring files.'
+  Enabled: true
+  VersionAdded: '0.78'
+  Safe: false
 
 Lint/NonLocalExitFromIterator:
   Description: 'Do not use return in iterator to cause non-local exit.'
@@ -1509,6 +1566,12 @@ Lint/PercentSymbolArray:
   Enabled: true
   VersionAdded: '0.41'
 
+Lint/RaiseException:
+  Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
+  StyleGuide: '#raise-exception'
+  Enabled: true
+  VersionAdded: '0.81'
+
 Lint/RandOne:
   Description: >-
     Checks for `rand(1)` calls. Such calls always return `0`
@@ -1537,7 +1600,14 @@ Lint/RedundantRequireStatement:
 Lint/RedundantSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
-  VersionChanged: '0.76'
+  VersionAdded: '0.76'
+
+Lint/RedundantStringCoercion:
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  StyleGuide: '#no-to-s'
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.77'
 
 Lint/RedundantWithIndex:
   Description: 'Checks for redundant `with_index`.'
@@ -1584,8 +1654,8 @@ Lint/SafeNavigationChain:
   Description: 'Do not chain ordinary method call after safe navigation operator.'
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '0.56'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -1599,13 +1669,13 @@ Lint/SafeNavigationConsistency:
     for all method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - present?
     - blank?
     - presence
     - try
     - try!
-
 
 Lint/SafeNavigationWithEmpty:
   Description: 'Avoid `foo&.empty?` in conditionals.'
@@ -1644,12 +1714,18 @@ Lint/ShadowingOuterLocalVariable:
   Enabled: true
   VersionAdded: '0.9'
 
-Lint/StringConversionInInterpolation:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: '#no-to-s'
+Lint/StructNewOverride:
+  Description: 'Disallow overriding the `Struct` built-in methods via `Struct.new`.'
   Enabled: true
-  VersionAdded: '0.19'
-  VersionChanged: '0.20'
+  VersionAdded: '0.81'
+
+Lint/SuppressedException:
+  Description: "Don't suppress exceptions."
+  StyleGuide: '#dont-hide-exceptions'
+  Enabled: false
+  AllowComments: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.81'
 
 Lint/Syntax:
   Description: 'Checks syntax error.'
@@ -1660,6 +1736,7 @@ Lint/Syntax:
 Lint/ToJSON:
   Description: 'Ensure #to_json includes an optional argument.'
   Enabled: true
+  VersionAdded: '0.66'
 
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
@@ -1691,9 +1768,10 @@ Lint/UnusedMethodArgument:
   StyleGuide: '#underscore-unused-vars'
   Enabled: true
   VersionAdded: '0.21'
-  VersionChanged: '0.35'
+  VersionChanged: '0.81'
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
+  IgnoreNotImplementedMethods: true
 
 Lint/UriEscapeUnescape:
   Description: >-
@@ -1739,6 +1817,8 @@ Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true
   VersionAdded: '0.13'
+  VersionChanged: '0.80'
+  Safe: false
 
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
@@ -1757,9 +1837,10 @@ Metrics/AbcSize:
     - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: false
   VersionAdded: '0.27'
-  VersionChanged: '0.66'
+  VersionChanged: '0.81'
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
+  IgnoredMethods: []
   Max: 15
 
 Metrics/BlockLength:
@@ -1799,30 +1880,9 @@ Metrics/CyclomaticComplexity:
     of test cases needed to validate a method.
   Enabled: false
   VersionAdded: '0.25'
+  VersionChanged: '0.81'
+  IgnoredMethods: []
   Max: 6
-
-Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: '#80-character-limits'
-  Enabled: false
-  VersionAdded: '0.25'
-  VersionChanged: '0.68'
-  AutoCorrect: false
-  Max: 80
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # containing a URI to be longer than Max.
-  AllowHeredoc: true
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
-  # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: false
-  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
-  # elements. Strings will be converted to Regexp objects. A line that matches
-  # any regular expression listed in this option will be ignored by LineLength.
-  IgnoredPatterns: []
 
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 10 lines of code.'
@@ -1855,6 +1915,8 @@ Metrics/PerceivedComplexity:
     human reader.
   Enabled: false
   VersionAdded: '0.25'
+  VersionChanged: '0.81'
+  IgnoredMethods: []
   Max: 7
 
 ################## Migration #############################
@@ -1863,7 +1925,8 @@ Migration/DepartmentName:
   Description: >-
     Check that cop names in rubocop:disable (etc) comments are
     given with department name.
-  Enabled: false
+  Enabled: true
+  VersionAdded: '0.75'
 
 #################### Naming ##############################
 
@@ -1884,6 +1947,21 @@ Naming/BinaryOperatorParameterName:
   StyleGuide: '#other-arg'
   Enabled: false
   VersionAdded: '0.50'
+
+Naming/BlockParameterName:
+  Description: >-
+                 Checks for block parameter names that contain capital letters,
+                 end in numbers, or do not meet a minimal length.
+  Enabled: false
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+  # Allowed names that will not register an offense
+  AllowedNames: []
+  # Forbidden names that will register an offense
+  ForbiddenNames: []
 
 Naming/ClassAndModuleCamelCase:
   Description: 'Use CamelCase for classes and modules.'
@@ -1976,7 +2054,7 @@ Naming/HeredocDelimiterNaming:
   StyleGuide: '#heredoc-delimiters'
   Enabled: true
   VersionAdded: '0.50'
-  Blacklist:
+  ForbiddenDelimiters:
     - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
 
 Naming/MemoizedInstanceVariableName:
@@ -2008,25 +2086,51 @@ Naming/MethodName:
   #
   IgnoredPatterns: []
 
+Naming/MethodParameterName:
+  Description: >-
+                 Checks for method parameter names that contain capital letters,
+                 end in numbers, or do not meet a minimal length.
+  Enabled: false
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  # Allowed names that will not register an offense
+  AllowedNames:
+    - io
+    - id
+    - to
+    - by
+    - 'on'
+    - in
+    - at
+    - ip
+    - db
+    - os
+    - pp
+  # Forbidden names that will register an offense
+  ForbiddenNames: []
+
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: '#bool-methods-qmark'
   Enabled: false # It is not very important for us and there are cases where people want to use it (See issue #6)
   VersionAdded: '0.50'
-  VersionChanged: '0.51'
+  VersionChanged: '0.77'
   # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
   # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - has_
     - have_
-  # Predicate names which, despite having a blacklisted prefix, or no `?`,
+  # Predicate names which, despite having a forbidden prefix, or no `?`,
   # should still be accepted
-  NameWhitelist:
+  AllowedMethods:
     - is_a?
   # Method definition macros for dynamically generated methods.
   MethodDefinitionMacros:
@@ -2043,46 +2147,6 @@ Naming/RescuedExceptionsVariableName:
   VersionAdded: '0.67'
   VersionChanged: '0.68'
   PreferredName: e
-
-Naming/UncommunicativeBlockParamName:
-  Description: >-
-    Checks for block parameter names that contain capital letters,
-    end in numbers, or do not meet a minimal length.
-  Enabled: false
-  VersionAdded: '0.53'
-  # Parameter names may be equal to or greater than this value
-  MinNameLength: 1
-  AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
-  AllowedNames: []
-  # Blacklisted names that will register an offense
-  ForbiddenNames: []
-
-Naming/UncommunicativeMethodParamName:
-  Description: >-
-    Checks for method parameter names that contain capital letters,
-    end in numbers, or do not meet a minimal length.
-  Enabled: false
-  VersionAdded: '0.53'
-  VersionChanged: '0.59'
-  # Parameter names may be equal to or greater than this value
-  MinNameLength: 3
-  AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
-  AllowedNames:
-    - io
-    - id
-    - to
-    - by
-    - 'on'
-    - in
-    - at
-    - ip
-    - db
-    - os
-  # Blacklisted names that will register an offense
-  ForbiddenNames: []
-
 
 Naming/VariableName:
   Description: 'Use the configured style when naming variables.'
@@ -2153,10 +2217,12 @@ Style/AccessModifierDeclarations:
   Description: 'Checks style of how access modifiers are used.'
   Enabled: true
   VersionAdded: '0.57'
+  VersionChanged: '0.81'
   EnforcedStyle: group
   SupportedStyles:
     - inline
     - group
+  AllowModifiersOnSymbols: true
 
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
@@ -2335,24 +2401,12 @@ Style/BlockDelimiters:
   #   # also good
   #   collection.each do |element| puts element end
   AllowBracesOnProceduralOneLiners: false
-
-Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
-  Enabled: false # Maybe discuss. We actually do want braces if a single hash is split across multiple lines.
-  VersionAdded: '0.14.1'
-  VersionChanged: '0.28'
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
+  # The BracesRequiredMethods overrides all other configurations except
+  # IgnoredMethods. It can be used to enforce that all blocks for specific
+  # methods use braces. For example, you can use this to enforce Sorbet
+  # signatures use braces even when the rest of your codebase enforces
+  # the `line_count_based` style.
+  BracesRequiredMethods: []
 
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
@@ -2422,7 +2476,7 @@ Style/ClassVars:
 # Align with the style guide.
 Style/CollectionMethods:
   Description: 'Preferred collection methods.'
-  StyleGuide: '#map-find-select-reduce-size'
+  StyleGuide: '#map-find-select-reduce-include-size'
   Enabled: false # We'll maybe enable this later.
   VersionAdded: '0.9'
   VersionChanged: '0.27'
@@ -2439,6 +2493,7 @@ Style/CollectionMethods:
     inject: 'reduce'
     detect: 'find'
     find_all: 'select'
+    member?: 'include?'
 
 Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
@@ -2664,6 +2719,7 @@ Style/EndBlock:
   StyleGuide: '#no-END-blocks'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.81'
 
 Style/EvalWithLocation:
   Description: 'Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by backtraces.'
@@ -2738,7 +2794,7 @@ Style/FrozenStringLiteralComment:
     to help transition to frozen string literals by default.
   Enabled: false
   VersionAdded: '0.36'
-  VersionChanged: '0.69'
+  VersionChanged: '0.79'
   EnforcedStyle: always
   SupportedStyles:
     # `always` will always add the frozen string literal comment to a file
@@ -2746,9 +2802,14 @@ Style/FrozenStringLiteralComment:
     # string literal. If you run code against multiple versions of Ruby, it is
     # possible that this will create errors in Ruby 2.3.0+.
     - always
+    # `always_true` will add the frozen string literal comment to a file,
+    # similarly to the `always` style, but will also change any disabled
+    # comments (e.g. `# frozen_string_literal: false`) to be enabled.
+    - always_true
     # `never` will enforce that the frozen string literal comment does not
     # exist in a file.
     - never
+  Safe: false
 
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
@@ -2768,6 +2829,13 @@ Style/GuardClause:
   # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
   # needs to have to trigger this cop
   MinBodyLength: 1
+
+Style/HashEachMethods:
+  Description: 'Use Hash#each_key and Hash#each_value.'
+  StyleGuide: '#hash-each'
+  Enabled: true
+  VersionAdded: '0.80'
+  Safe: false
 
 Style/HashSyntax:
   Description: >-
@@ -2791,6 +2859,18 @@ Style/HashSyntax:
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Style/HashTransformKeys:
+  Description: 'Prefer `transform_keys` over `each_with_object` and `map`.'
+  Enabled: true
+  VersionAdded: '0.80'
+  Safe: false
+
+Style/HashTransformValues:
+  Description: 'Prefer `transform_values` over `each_with_object` and `map`.'
+  Enabled: true
+  VersionAdded: '0.80'
+  Safe: false
 
 Style/IdenticalConditionalBranches:
   Description: >-
@@ -2878,8 +2958,9 @@ Style/IpAddresses:
   Description: "Don't include literal IP addresses in code."
   Enabled: false
   VersionAdded: '0.58'
-  # Allow strings to be whitelisted
-  Whitelist:
+  VersionChanged: '0.77'
+  # Allow addresses to be permitted
+  AllowedAddresses:
     - "::"
     # :: is a valid IPv6 address, but could potentially be legitimately in code
 
@@ -2899,7 +2980,7 @@ Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   StyleGuide: '#proc-call'
   Enabled: true
-  VersionAdded: '0.13.1'
+  VersionAdded: '0.13'
   VersionChanged: '0.14'
   EnforcedStyle: call
   SupportedStyles:
@@ -3029,6 +3110,7 @@ Style/ModuleFunction:
   SupportedStyles:
     - module_function
     - extend_self
+    - forbidden
   Autocorrect: false
   SafeAutoCorrect: false
 
@@ -3154,8 +3236,8 @@ Style/NestedParenthesizedCalls:
     argument list of another parenthesized method call.
   Enabled: true
   VersionAdded: '0.36'
-  VersionChanged: '0.50'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - be
     - be_a
     - be_an
@@ -3532,11 +3614,11 @@ Style/SafeNavigation:
     safe navigation (`&.`).
   Enabled: true
   VersionAdded: '0.43'
-  VersionChanged: '0.56'
+  VersionChanged: '0.77'
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -3770,14 +3852,21 @@ Style/TrailingCommaInArrayLiteral:
   StyleGuide: '#no-trailing-array-commas'
   Enabled: true
   VersionAdded: '0.53'
+  # If `comma`, the cop requires a comma after the last item in an array,
   # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array literals.
+  # non-empty, multiline array literals.
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
+
+Style/TrailingCommaInBlockArgs:
+  Description: 'Checks for useless trailing commas in block arguments.'
+  Enabled: false
+  Safe: false
+  VersionAdded: '0.81'
 
 Style/TrailingCommaInHashLiteral:
   Description: 'Checks for trailing comma in hash literals.'
@@ -3785,7 +3874,7 @@ Style/TrailingCommaInHashLiteral:
   # If `comma`, the cop requires a comma after the last item in a hash,
   # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty hash literals.
+  # non-empty, multiline hash literals.
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
@@ -3814,7 +3903,7 @@ Style/TrivialAccessors:
   StyleGuide: '#attr_family'
   Enabled: false
   VersionAdded: '0.9'
-  VersionChanged: '0.38'
+  VersionChanged: '0.77'
   # When set to `false` the cop will suggest the use of accessor methods
   # in situations like:
   #
@@ -3835,7 +3924,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c

--- a/config/ext/rails.yml
+++ b/config/ext/rails.yml
@@ -62,7 +62,7 @@ Rails/ActiveSupportAliases:
 
 Rails/ApplicationController:
   Description: 'Check that controllers subclass ApplicationController.'
-  Enabled: true
+  Enabled: false # We have Controllers like `/jasmine` which do not inherit from ApplicationController
   SafeAutoCorrect: false
   VersionAdded: '2.4'
   VersionChanged: '2.5'
@@ -364,7 +364,7 @@ Rails/Present:
 
 Rails/RakeEnvironment:
   Description: 'Include `:environment` as a dependency for all Rake tasks.'
-  Enabled: true
+  Enabled: false
   Safe: false
   VersionAdded: '2.4'
   Include:

--- a/config/ext/rails.yml
+++ b/config/ext/rails.yml
@@ -1,6 +1,10 @@
 require:
   - rubocop-rails
 
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   Exclude:
     - 'node_modules/**/*'
@@ -56,15 +60,33 @@ Rails/ActiveSupportAliases:
   Enabled: false
   VersionAdded: '0.48'
 
+Rails/ApplicationController:
+  Description: 'Check that controllers subclass ApplicationController.'
+  Enabled: true
+  SafeAutoCorrect: false
+  VersionAdded: '2.4'
+  VersionChanged: '2.5'
+
 Rails/ApplicationJob:
   Description: 'Check that jobs subclass ApplicationJob.'
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '0.49'
+  VersionChanged: '2.5'
+
+Rails/ApplicationMailer:
+  Description: 'Check that mailers subclass ApplicationMailer.'
+  Enabled: true
+  SafeAutoCorrect: false
+  VersionAdded: '2.4'
+  VersionChanged: '2.5'
 
 Rails/ApplicationRecord:
   Description: 'Check that models subclass ApplicationRecord.'
   Enabled: false # Because not all models are necessarily domain models (e.g. migration models for legacy databases)
+  SafeAutoCorrect: false
   VersionAdded: '0.49'
+  VersionChanged: '2.5'
 
 Rails/AssertNot:
   Description: 'Use `assert_not` instead of `assert !`.'
@@ -190,8 +212,8 @@ Rails/FilePath:
   Description: 'Use `Rails.root.join` for file path joining.'
   Enabled: false
   VersionAdded: '0.47'
-  VersionChanged: '0.57'
-  EnforcedStyle: arguments
+  VersionChanged: '2.4'
+  EnforcedStyle: slashes
   SupportedStyles:
     - slashes
     - arguments
@@ -259,6 +281,16 @@ Rails/IgnoredSkipActionFilterOption:
   VersionAdded: '0.63'
   Include:
     - app/controllers/**/*.rb
+
+Rails/IndexBy:
+  Description: 'Prefer `index_by` over `each_with_object` or `map`.'
+  Enabled: true
+  VersionAdded: '2.5'
+
+Rails/IndexWith:
+  Description: 'Prefer `index_with` over `each_with_object` or `map`.'
+  Enabled: true
+  VersionAdded: '2.5'
 
 Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
@@ -330,6 +362,17 @@ Rails/Present:
   # Convert usages of `unless blank?` to `if present?`
   UnlessBlank: true
 
+Rails/RakeEnvironment:
+  Description: 'Include `:environment` as a dependency for all Rake tasks.'
+  Enabled: true
+  Safe: false
+  VersionAdded: '2.4'
+  Include:
+    - '**/Rakefile'
+    - '**/*.rake'
+  Exclude:
+    - 'lib/capistrano/tasks/**/*.rake'
+
 Rails/ReadWriteAttribute:
   Description: >-
     Checks for read_attribute(:attr) and
@@ -364,6 +407,10 @@ Rails/RefuteMethods:
   Description: 'Use `assert_not` methods instead of `refute` methods.'
   Enabled: true
   VersionAdded: '0.56'
+  EnforcedStyle: assert_not
+  SupportedStyles:
+    - assert_not
+    - refute
   Include:
     - '**/test/**/*'
 
@@ -401,6 +448,18 @@ Rails/SafeNavigation:
   # both raise a `NoMethodError` if the receiver of the method call does not
   # implement the intended method. `try` will not raise an exception for this.
   ConvertTry: false
+
+Rails/SafeNavigationWithBlank:
+  Description: 'Avoid `foo&.blank?` in conditionals.'
+  Enabled: true
+  VersionAdded: '2.4'
+  # While the safe navigation operator is generally a good idea, when
+  # checking `foo&.blank?` in a conditional, `foo` being `nil` will actually
+  # do the opposite of what the author intends.
+  #
+  # foo&.blank? #=> nil
+  # foo.blank? #=> true
+  SafeAutoCorrect: false
 
 Rails/SaveBang:
   Description: 'Identifies possible cases where Active Record save! or related should be used.'
@@ -466,6 +525,13 @@ Rails/UniqBeforePluck:
     - conservative
     - aggressive
   AutoCorrect: false
+
+Rails/UniqueValidationWithoutIndex:
+  Description: 'Uniqueness validation should be with a unique index.'
+  Enabled: true
+  VersionAdded: '2.5'
+  Include:
+    - app/models/**/*.rb
 
 Rails/UnknownEnv:
   Description: 'Use correct environment name.'

--- a/makandra-rubocop.gemspec
+++ b/makandra-rubocop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r(^exe/)) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.76.0'
+  spec.add_dependency 'rubocop', '~> 0.81.0'
   spec.add_dependency 'rubocop-rails', '~> 2.3.2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/makandra-rubocop.gemspec
+++ b/makandra-rubocop.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.81.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.3.2'
+  spec.add_dependency 'rubocop-rails', '~> 2.5.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
* Update rubocop from 0.76.0 to 0.81.0
* Upgrade rubocop-rails from 2.3.2 to 2.5.1

@foobear Can you please review the new cops? Maybe we want to disable some of them before rolling out this release.