### PR TITLE
Add factory bot and capybara

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+- Add default configuration for `rubocop-capybara` and `rubocop-factory_bot`
+
 
 ## 12.0.0 - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+
+## 12.1.0 - 2024-01-07
+
+### Compatible changes
+
 - Add default configuration for `rubocop-capybara` and `rubocop-factory_bot`
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,50 @@
 PATH
   remote: .
   specs:
-    makandra-rubocop (12.0.0)
+    makandra-rubocop (12.1.0)
       rubocop (~> 1.60.0)
+      rubocop-capybara (~> 2.20.0)
+      rubocop-factory_bot (~> 2.25.1)
       rubocop-rails (~> 2.23.1)
       rubocop-rspec (~> 2.13.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.3)
+    activesupport (7.1.3)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
-    concurrent-ruby (1.2.2)
-    i18n (1.12.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
-    minitest (5.18.0)
-    parallel (1.22.1)
-    parser (3.3.0.4)
+    minitest (5.21.2)
+    mutex_m (0.2.0)
+    parallel (1.24.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
-    rack (3.0.7)
+    rack (3.0.9)
     rainbow (3.1.1)
     rake (12.3.2)
-    regexp_parser (2.7.0)
-    rexml (3.2.5)
-    rubocop (1.60.0)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -45,6 +57,10 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
     rubocop-rails (2.23.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
@@ -53,10 +69,10 @@ GEM
     rubocop-rspec (2.13.2)
       rubocop (~> 1.33)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.2)
-    zeitwerk (2.6.7)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ inherit_gem:
     - config/ext/rspec.yml
 ```
 
+**For Capybara**
+
+```yaml
+inherit_gem:
+  makandra-rubocop:
+    - config/default.yml
+    - config/ext/capybara.yml
+```
+
+**For Factory Bot**
+
+```yaml
+inherit_gem:
+  makandra-rubocop:
+    - config/default.yml
+    - config/ext/factory_bot.yml
+```
+
 Any per-project rules can then be defined in the `.rubocop.yml`:
 
 ```yaml

--- a/config/ext/capybara.yml
+++ b/config/ext/capybara.yml
@@ -1,0 +1,105 @@
+require:
+  - rubocop-capybara
+
+inherit_mode:
+  merge:
+    - Exclude
+
+Capybara:
+  Enabled: true
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-capybara
+  Include: &1
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/*_steps.rb"
+    - "**/features/step_definitions/**/*"
+
+Capybara/ClickLinkOrButtonStyle:
+  Description: Checks for methods of button or link clicks.
+  Enabled: pending
+  VersionAdded: '2.19'
+  VersionChanged: '2.20'
+  EnforcedStyle: link_or_button
+  SupportedStyles:
+    - link_or_button
+    - strict
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/ClickLinkOrButtonStyle
+
+Capybara/CurrentPathExpectation:
+  Description: Checks that no expectations are set on Capybara's `current_path`.
+  Enabled: true
+  VersionAdded: '1.18'
+  VersionChanged: '2.0'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/CurrentPathExpectation
+
+Capybara/MatchStyle:
+  Description: Checks for usage of deprecated style methods.
+  Enabled: pending
+  VersionAdded: '2.17'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/MatchStyle
+
+Capybara/NegationMatcher:
+  Description: Enforces use of `have_no_*` or `not_to` for negated expectations.
+  Enabled: pending
+  VersionAdded: '2.14'
+  VersionChanged: '2.20'
+  EnforcedStyle: have_no
+  SupportedStyles:
+    - have_no
+    - not_to
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/NegationMatcher
+
+Capybara/RedundantWithinFind:
+  Description: Checks for redundant `within find(...)` calls.
+  Enabled: pending
+  VersionAdded: '2.20'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RedundantWithinFind
+
+Capybara/SpecificActions:
+  Description: Checks for there is a more specific actions offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.14'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/SpecificActions
+
+Capybara/SpecificFinders:
+  Description: Checks if there is a more specific finder offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.13'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/SpecificFinders
+
+Capybara/SpecificMatcher:
+  Description: Checks for there is a more specific matcher offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.12'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/SpecificMatcher
+
+Capybara/VisibilityMatcher:
+  Description: Checks for boolean visibility in Capybara finders.
+  Enabled: true
+  VersionAdded: '1.39'
+  VersionChanged: '2.0'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/VisibilityMatcher
+
+Capybara/RSpec:
+  Enabled: true
+  Include: *1
+
+Capybara/RSpec/HaveSelector:
+  Description: Use `have_css` or `have_xpath` instead of `have_selector`.
+  Enabled: pending
+  DefaultSelector: css
+  VersionAdded: '2.19'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/HaveSelector
+
+Capybara/RSpec/PredicateMatcher:
+  Description: Prefer using predicate matcher over using predicate method directly.
+  Enabled: pending
+  Strict: true
+  EnforcedStyle: inflected
+  AllowedExplicitMatchers: []
+  SupportedStyles:
+    - inflected
+    - explicit
+  VersionAdded: '2.19'
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/PredicateMatcher

--- a/config/ext/factory_bot.yml
+++ b/config/ext/factory_bot.yml
@@ -1,0 +1,148 @@
+require:
+  - rubocop-factory_bot
+
+inherit_mode:
+  merge:
+    - Exclude
+
+FactoryBot:
+  Enabled: true
+  Include:
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/test/factories.rb"
+    - "**/test/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-factory_bot
+
+FactoryBot/AssociationStyle:
+  Description: Use a consistent style to define associations.
+  Enabled: pending
+  Safe: false
+  VersionAdded: '2.23'
+  VersionChanged: '2.24'
+  EnforcedStyle: implicit
+  SupportedStyles:
+    - explicit
+    - implicit
+  NonImplicitAssociationMethodNames: ~
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/AssociationStyle
+
+FactoryBot/AttributeDefinedStatically:
+  Description: Always declare attribute values as blocks.
+  Enabled: true
+  VersionAdded: '1.28'
+  VersionChanged: '2.24'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/AttributeDefinedStatically
+
+FactoryBot/ConsistentParenthesesStyle:
+  Description: Use a consistent style for parentheses in factory_bot calls.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - omit_parentheses
+  ExplicitOnly: false
+  VersionAdded: '2.14'
+  VersionChanged: '2.23'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/ConsistentParenthesesStyle
+
+FactoryBot/CreateList:
+  Description: Checks for create_list usage.
+  Enabled: true
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  EnforcedStyle: create_list
+  SupportedStyles:
+    - create_list
+    - n_times
+  ExplicitOnly: false
+  SafeAutoCorrect: false
+  VersionAdded: '1.25'
+  VersionChanged: '2.24'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/CreateList
+
+FactoryBot/ExcessiveCreateList:
+  Description: Check for excessive model creation in a list.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  MaxAmount: 10
+  VersionAdded: '2.25'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/ExcessiveCreateList
+
+FactoryBot/FactoryAssociationWithStrategy:
+  Description: Use definition in factory association instead of hard coding a strategy.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  VersionAdded: '2.23'
+  VersionChanged: '2.23'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryAssociationWithStrategy
+
+FactoryBot/FactoryClassName:
+  Description: Use string value when setting the class attribute explicitly.
+  Enabled: true
+  VersionAdded: '1.37'
+  VersionChanged: '2.24'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryClassName
+
+FactoryBot/FactoryNameStyle:
+  Description: Checks for name style for argument of FactoryBot::Syntax::Methods.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  EnforcedStyle: symbol
+  SupportedStyles:
+    - symbol
+    - string
+  ExplicitOnly: false
+  VersionAdded: '2.16'
+  VersionChanged: '2.23'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/FactoryNameStyle
+
+FactoryBot/IdSequence:
+  Description: Do not create a FactoryBot sequence for an id column.
+  Enabled: pending
+  VersionAdded: '2.24'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/IdSequence
+
+FactoryBot/RedundantFactoryOption:
+  Description: Checks for redundant `factory` option.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  VersionAdded: '2.23'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/RedundantFactoryOption
+
+FactoryBot/SyntaxMethods:
+  Description: Use shorthands from `FactoryBot::Syntax::Methods` in your specs.
+  Enabled: pending
+  Include:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
+    - "**/features/support/factories/**/*.rb"
+  SafeAutoCorrect: false
+  VersionAdded: '2.7'
+  Reference: https://www.rubydoc.info/gems/rubocop-factory_bot/RuboCop/Cop/FactoryBot/SyntaxMethods

--- a/lib/makandra_rubocop/version.rb
+++ b/lib/makandra_rubocop/version.rb
@@ -1,3 +1,3 @@
 module MakandraRubocop
-  VERSION = '12.0.0'.freeze
+  VERSION = '12.1.0'.freeze
 end

--- a/makandra-rubocop.gemspec
+++ b/makandra-rubocop.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 1.60.0'
   spec.add_dependency 'rubocop-rails', '~> 2.23.1'
   spec.add_dependency 'rubocop-rspec', '~> 2.13.2'
+  spec.add_dependency 'rubocop-capybara', '~> 2.20.0'
+  spec.add_dependency 'rubocop-factory_bot', '~> 2.25.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
PR to add default configs for rubocop-factory_bot and rubocop-capybara (see #45). I decided to not add `rubocop-rake`, since it seems not be actively used anymore.

There are a few cops in the `pending` state. As far as I understand, we follow the approach of Rubocop to keep then on pending until the next major release and the community has decided to enable or disable a cop.

I added this config to a larger project and the changes were straight forward. I linked the PR for the larger project to this PR, so cops can be discussed here.